### PR TITLE
Minitest integration

### DIFF
--- a/lib/shoulda.rb
+++ b/lib/shoulda.rb
@@ -4,6 +4,8 @@ if defined?(RSpec)
   require 'shoulda/integrations/rspec2'
 elsif defined?(Spec)
   require 'shoulda/integrations/rspec'
+elsif defined?(MiniTest::Unit)
+  require 'shoulda/integrations/minitest'
 else
   require 'shoulda/integrations/test_unit'
 end

--- a/lib/shoulda/integrations/minitest.rb
+++ b/lib/shoulda/integrations/minitest.rb
@@ -1,0 +1,19 @@
+require 'shoulda/context'
+require 'shoulda/proc_extensions'
+require 'shoulda/assertions'
+require 'shoulda/macros'
+require 'shoulda/helpers'
+require 'shoulda/autoload_macros'
+require 'shoulda/rails' if defined? RAILS_ROOT
+
+module MiniTest # :nodoc: all
+  class Unit
+    class TestCase
+      include Shoulda::InstanceMethods
+      extend Shoulda::ClassMethods
+      include Shoulda::Assertions
+      extend Shoulda::Macros
+      include Shoulda::Helpers
+    end
+  end
+end


### PR DESCRIPTION
Adds rudimentary support for MiniTest.

Rails integration is still tightly coupled with Test::Unit -- some refactoring should be done before MiniTest support is added.

Are you interested in this? If so, I'll work on the Rails integration afterwards.
