### PR TITLE
Add backtrace to show where the should was called from if should is broken

### DIFF
--- a/lib/shoulda/context.rb
+++ b/lib/shoulda/context.rb
@@ -327,6 +327,7 @@ module Shoulda
       end
 
       if blk
+        blk = add_shoulda_backtrace_for_block(blk)
         self.shoulds << { :name => name, :before => options[:before], :block => blk }
       else
        self.should_eventuallys << { :name => name }
@@ -336,6 +337,7 @@ module Shoulda
     def should_not(matcher)
       name = matcher.description
       blk = lambda { assert_rejects matcher, subject }
+      blk = add_shoulda_backtrace_for_block(blk)
       self.shoulds << { :name => "not #{name}", :block => blk }
     end
 
@@ -435,6 +437,18 @@ module Shoulda
 
     def method_missing(method, *args, &blk)
       test_unit_class.send(method, *args, &blk)
+    end
+
+    private
+    # Adds the backtrace for should method
+    # where the should method is called
+    def add_shoulda_backtrace_for_block(block)
+      backtrace = caller(1)
+
+      lambda do
+        @shoulda_backtrace = backtrace
+        block.bind(self).call
+      end
     end
 
   end

--- a/lib/shoulda/defect_localization_extension.rb
+++ b/lib/shoulda/defect_localization_extension.rb
@@ -1,0 +1,85 @@
+#
+# 1 class PersonsControllerTest < ActionController::TestCase
+# 2
+# 3   context "on get :show" do
+# 4     setup do
+# 5       @person = Person.first
+# 6       get :show, :id => @person.id
+# 7     end
+# 8
+# 9     should respond_with :success
+#10   end
+#11 end
+#
+#
+#1) Failure:
+#test: on get :show should respond with :success. (PersonsControllerTest)
+#[DEFECT:1
+#     /test/functional/persons_controller_test.rb:9:in `__bind_1290606365_660643'
+#
+#
+#SHOULD_BACKTRACE:2
+#/test/functional/blog/tags_controller_test.rb:9:in `__bind_1290606365_660643'
+#shoulda (2.11.3) lib/shoulda/context.rb:306:in `call'
+#shoulda (2.11.3) lib/shoulda/context.rb:306:in `merge_block'
+#shoulda (2.11.3) lib/shoulda/context.rb:301:in `initialize'
+#shoulda (2.11.3) lib/shoulda/context.rb:199:in `new'
+#shoulda (2.11.3) lib/shoulda/context.rb:199:in `context'
+#/test/functional/persons_controller_test.rb:3
+#...
+#-e:1
+#-e:1:in `each'
+#-e:1
+#
+#
+#ASSERTION_BACKTRACE:3
+#shoulda (2.11.3) lib/shoulda/assertions.rb:59:in `assert_accepts'
+#shoulda (2.11.3) lib/shoulda/context.rb:382:in `call'
+#shoulda (2.11.3) lib/shoulda/context.rb:382:in `test: on get :show should respond with :success. '
+#activesupport (2.3.10) lib/active_support/testing/setup_and_teardown.rb:62:in `__send__'
+#activesupport (2.3.10) lib/active_support/testing/setup_and_teardown.rb:62:in `run'
+#response to be a 200, but was 303
+
+module Shoulda
+  module DefectLocalizationExtension
+    def assert_block(*args)
+      begin
+        super
+      rescue Test::Unit::AssertionFailedError => exception
+        set_backtrace_for_exception(exception)
+        raise exception
+      end
+    end
+
+    private
+    def set_backtrace_for_exception(exception)
+      if @shoulda_backtrace
+        backtrace = [extract_shoulda_assertion(exception),
+          extract_complete_shoulda_backtrace,
+          extract_complete_assertion_backtrace(exception)].flatten.compact
+
+        exception.set_backtrace(backtrace)
+      end
+    end
+
+    def extract_shoulda_assertion(exception)
+      backtrace = @shoulda_backtrace + exception.backtrace
+      backtrace = backtrace.grep(/#{self.class.to_s.underscore}\.rb\:[0-9]*/)
+      backtrace = backtrace.sort_by {|code_line| code_line.match(/\.rb\:([0-9]*)/)[1].to_i}.reverse
+
+      assertion ||= backtrace.detect do |code_line|
+        code_line.match(/#{self.class.to_s.underscore}\.rb\:[0-9]*/)
+      end
+
+      ["DEFECT:1", assertion, '']
+    end
+
+    def extract_complete_shoulda_backtrace
+      ["SHOULD_BACKTRACE:2", @shoulda_backtrace, '']
+    end
+
+    def extract_complete_assertion_backtrace(exception)
+      ["ASSERTION_BACKTRACE:3", exception.backtrace]
+    end
+  end
+end

--- a/lib/shoulda/integrations/test_unit.rb
+++ b/lib/shoulda/integrations/test_unit.rb
@@ -7,6 +7,7 @@ require 'shoulda/macros'
 require 'shoulda/helpers'
 require 'shoulda/autoload_macros'
 require 'shoulda/rails' if defined? RAILS_ROOT
+require 'shoulda/defect_localization_extension'
 
 module Test # :nodoc: all
   module Unit
@@ -16,6 +17,7 @@ module Test # :nodoc: all
       include Shoulda::Assertions
       extend Shoulda::Macros
       include Shoulda::Helpers
+      include Shoulda::DefectLocalizationExtension
     end
   end
 end


### PR DESCRIPTION
fixes feature https://github.com/thoughtbot/shoulda/issues/#issue/30
- show the line number in the test of the defect (DEFECT)
- list the should_backtrace where the should was called from (SHOULD_BACKTRACE)
- list the normal assertion backtrace (ASSERTION_BACKTRACE)
