### PR TITLE
Add support to ensure_inclusion_of for enums

### DIFF
--- a/lib/shoulda/active_record/macros.rb
+++ b/lib/shoulda/active_record/macros.rb
@@ -167,7 +167,7 @@ module Shoulda # :nodoc:
       #   Regexp or string.  Default = <tt>I18n.translate('activerecord.errors.messages.too_long') % range.last</tt>
       #
       # Example:
-      #   should_ensure_length_in_range :password, (6..20)
+      #   should_ensure_length_in :password, (6..20)
       #
       def should_ensure_length_in_range(attribute, range, opts = {})
         ::ActiveSupport::Deprecation.warn("use: should ensure_length_of.is_at_least.is_at_most")
@@ -231,16 +231,16 @@ module Shoulda # :nodoc:
       #   Regexp or string.  Default = <tt>I18n.translate('activerecord.errors.messages.inclusion')</tt>
       #
       # Example:
-      #   should_ensure_value_in_range :age, (0..100)
+      #   should_ensure_value_in :age, (0..100)
       #
       def should_ensure_value_in_range(attribute, range, opts = {})
-        ::ActiveSupport::Deprecation.warn("use: should ensure_inclusion_of.in_range")
+        ::ActiveSupport::Deprecation.warn("use: should ensure_inclusion_of.in")
         message, low_message, high_message = get_options!([opts],
                                                           :message,
                                                           :low_message,
                                                           :high_message)
         should ensure_inclusion_of(attribute).
-          in_range(range).
+          in(range).
           with_message(message).
           with_low_message(low_message).
           with_high_message(high_message)

--- a/lib/shoulda/active_record/matchers/ensure_inclusion_of_matcher.rb
+++ b/lib/shoulda/active_record/matchers/ensure_inclusion_of_matcher.rb
@@ -5,7 +5,7 @@ module Shoulda # :nodoc:
       # Ensure that the attribute's value is in the range specified
       #
       # Options:
-      # * <tt>in_range</tt> - the range of allowed values for this attribute
+      # * <tt>in</tt> - the set of allows values for this attribute
       # * <tt>with_low_message</tt> - value the test expects to find in
       #   <tt>errors.on(:attribute)</tt>. Regexp or string. Defaults to the
       #   translation for :inclusion.
@@ -22,17 +22,19 @@ module Shoulda # :nodoc:
 
       class EnsureInclusionOfMatcher < ValidationMatcher # :nodoc:
 
-        def in_range(range)
-          @range = range
-          @minimum = range.first
-          @maximum = range.last
+        def in(enum)
+          @enum = enum
           self
         end
 
         def with_message(message)
           if message
-            @low_message = message
-            @high_message = message
+            if @enum.kind_of? Range
+              @low_message = message
+              @high_message = message
+            else
+              @message = message
+            end
           end
           self
         end
@@ -48,37 +50,52 @@ module Shoulda # :nodoc:
         end
 
         def description
-          "ensure inclusion of #{@attribute} in #{@range.inspect}"
+          "ensure inclusion of #{@attribute} in #{ @enum.inspect }"
         end
 
         def matches?(subject)
           super(subject)
 
-          @low_message  ||= :inclusion
-          @high_message ||= :inclusion
+          if @enum.kind_of?(Range)
+            @low_message  ||= :inclusion
+            @high_message ||= :inclusion
 
-          disallows_lower_value &&
-            allows_minimum_value &&
-            disallows_higher_value &&
-            allows_maximum_value
+            disallows_lower_value &&
+              allows_minimum_value &&
+              disallows_higher_value &&
+              allows_maximum_value
+          else
+            @message      ||= :inclusion
+
+            allows_correct_value &&
+              disallows_incorrect_value
+          end
         end
 
         private
 
         def disallows_lower_value
-          @minimum == 0 || disallows_value_of(@minimum - 1, @low_message)
+          @enum.min == 0 || disallows_value_of(@enum.min - 1, @low_message)
         end
 
         def disallows_higher_value
-          disallows_value_of(@maximum + 1, @high_message)
+          disallows_value_of(@enum.max + 1, @high_message)
         end
 
         def allows_minimum_value
-          allows_value_of(@minimum, @low_message)
+          allows_value_of(@enum.min, @low_message)
         end
 
         def allows_maximum_value
-          allows_value_of(@maximum, @high_message)
+          allows_value_of(@enum.max, @high_message)
+        end
+
+        def allows_correct_value
+          allows_value_of(@enum.first, @message)
+        end
+
+        def disallows_incorrect_value
+          disallows_value_of(Object.new, @message)
         end
       end
 

--- a/test/matchers/active_record/ensure_inclusion_of_matcher_test.rb
+++ b/test/matchers/active_record/ensure_inclusion_of_matcher_test.rb
@@ -2,6 +2,45 @@ require 'test_helper'
 
 class EnsureInclusionOfMatcherTest < ActiveSupport::TestCase # :nodoc:
 
+  context "an attribute which must be included in an enumerable" do
+    setup do
+      @model = define_model(:example, :attr => :string) do
+        validates_inclusion_of :attr, :in => ['foo', 'bar']
+      end.new
+    end
+
+    should "accept ensuring a correct value" do
+      assert_accepts ensure_inclusion_of(:attr).in(['foo', 'bar']), @model
+    end
+
+    should "reject ensuring an incorrect value" do
+      assert_rejects ensure_inclusion_of(:attr).in(['baz', 'quux']), @model
+    end
+
+    should "not override the default message with a blank" do
+      assert_accepts ensure_inclusion_of(:attr).
+                       in(['foo', 'bar']).
+                       with_message(nil),
+                     @model
+    end
+  end
+
+  context "an attribute which must be included in an enumerable with a custom message" do
+    setup do
+      @model = define_model(:example, :attr => :string) do
+        validates_inclusion_of :attr, :in => ['foo', 'bar'], :message => 'not good'
+
+      end.new
+    end
+
+    should "accept ensuring the correct value" do
+      assert_accepts ensure_inclusion_of(:attr).
+                       in(['foo', 'bar']).
+                       with_message(/not good/),
+                     @model
+    end
+  end
+
   context "an attribute which must be included in a range" do
     setup do
       @model = define_model(:example, :attr => :integer) do
@@ -10,28 +49,28 @@ class EnsureInclusionOfMatcherTest < ActiveSupport::TestCase # :nodoc:
     end
 
     should "accept ensuring the correct range" do
-      assert_accepts ensure_inclusion_of(:attr).in_range(2..5), @model
+      assert_accepts ensure_inclusion_of(:attr).in(2..5), @model
     end
 
     should "reject ensuring a lower minimum value" do
-      assert_rejects ensure_inclusion_of(:attr).in_range(1..5), @model
+      assert_rejects ensure_inclusion_of(:attr).in(1..5), @model
     end
 
     should "reject ensuring a higher minimum value" do
-      assert_rejects ensure_inclusion_of(:attr).in_range(3..5), @model
+      assert_rejects ensure_inclusion_of(:attr).in(3..5), @model
     end
 
     should "reject ensuring a lower maximum value" do
-      assert_rejects ensure_inclusion_of(:attr).in_range(2..4), @model
+      assert_rejects ensure_inclusion_of(:attr).in(2..4), @model
     end
 
     should "reject ensuring a higher maximum value" do
-      assert_rejects ensure_inclusion_of(:attr).in_range(2..6), @model
+      assert_rejects ensure_inclusion_of(:attr).in(2..6), @model
     end
 
     should "not override the default message with a blank" do
       assert_accepts ensure_inclusion_of(:attr).
-                       in_range(2..5).
+                       in(2..5).
                        with_message(nil),
                      @model
     end
@@ -47,7 +86,7 @@ class EnsureInclusionOfMatcherTest < ActiveSupport::TestCase # :nodoc:
 
     should "accept ensuring the correct range" do
       assert_accepts ensure_inclusion_of(:attr).
-                       in_range(2..4).
+                       in(2..4).
                        with_message(/not good/),
                      @model
     end
@@ -70,7 +109,7 @@ class EnsureInclusionOfMatcherTest < ActiveSupport::TestCase # :nodoc:
 
     should "accept ensuring the correct range and messages" do
       assert_accepts ensure_inclusion_of(:attr).
-                       in_range(2..5).
+                       in(2..5).
                        with_low_message(/low/).
                        with_high_message(/high/),
                      @model


### PR DESCRIPTION
I've made changes to ensure_inclusion_of to more closely match the ActiveRecord API and also to support matching on both ranges and enums.
