### PR TITLE
Rails3 multipart emails

### DIFF
--- a/lib/shoulda/action_mailer/matchers/have_sent_email.rb
+++ b/lib/shoulda/action_mailer/matchers/have_sent_email.rb
@@ -123,9 +123,7 @@ module Shoulda # :nodoc:
           # body if the e-mail is multipart. TMail concatenates the
           # String representation of each part instead.
           if mail.body.blank? && mail.multipart?
-            mail.parts.select {|p| p.content_type =~ /^text\//}.all? do |part|
-              regexp_or_string_match(part.body, a_regexp_or_string)
-            end
+            part_match(mail, /^text\//, a_regexp_or_string)
           else
             regexp_or_string_match(mail.body, a_regexp_or_string)
           end


### PR DESCRIPTION
Hello,

the attached commits make should have_sent_email() work with `Mail` objects generated by `ActionMailer` 3, whose `.body` method that behave differently than the old `TMail` one: the former returns a blank body when the mail is `multipart?`, whilst the latter returns a concatenated (decoded) representation of all the e-mail parts.

Moreover, we were in the need to match a string into a part with a specific content-type of a multipart e-mail, thus we added them.

Hope you like the changes, and thank you for writing shoulda! :-)

~Marcello
