### PR TITLE
Fix build status image and add dependency status image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# shoulda [![Build Status](http://travis-ci.org/thoughtbot/shoulda.png)](http://travis-ci.org/thoughtbot/shoulda)
+# shoulda [![Build Status](https://secure.travis-ci.org/thoughtbot/shoulda.png)](http://travis-ci.org/thoughtbot/shoulda) [![Dependency Status](https://gemnasium.com/thoughtbot/shoulda.png)](https://gemnasium.com/thoughtbot/shoulda)
 
 The shoulda gem is a meta gem with two dependencies:
 


### PR DESCRIPTION
Serving up the build status image over HTTPS avoids a weird GitHub caching issue. Thanks guys!
