### PR TITLE
Specify pessimistic version constraint with two digits of precision

### DIFF
--- a/shoulda.gemspec
+++ b/shoulda.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("shoulda-context", "~> 1.0.1")
-  s.add_dependency("shoulda-matchers", "~> 1.4.1")
+  s.add_dependency("shoulda-context", ["~> 1.0", ">= 1.0.1"])
+  s.add_dependency("shoulda-matchers", ["~> 1.0", ">= 1.4.1"])
 
   s.add_development_dependency('appraisal',   '~> 0.4.0')
   s.add_development_dependency("rails", "3.0.12")


### PR DESCRIPTION
Assumes semantic versioning of `shoulda-context` and `shoulda-matchers`. See also: https://github.com/thoughtbot/shoulda/pull/232.
