### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 rvm:
   - 1.8.7
   - 1.9.2
-gemfile:
-  - gemfiles/3.0.gemfile
-  - gemfiles/3.1.gemfile
-  - gemfiles/3.2.gemfile


### PR DESCRIPTION
This is another attempt at what was started in #232.

We already use Appraisal for dependency regression tests. The .travis.yml file had a gemfiles declaration that competes with Appraisal. Combining the two caused Travis to blow up because Travis tries to run the suite against a particular (generated) gemfile, but the default rake task cleans that same gem file.

I'll pull this in once the Travis build goes green for this PR.
