### PR TITLE
Drop Ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
-
-matrix:
-  allow_failures:
-    - rvm: 1.8.7


### PR DESCRIPTION
In light of http://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/
we are dropping support for Ruby 1.8.7.