### PR TITLE
Cache Bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+
+sudo: false
+cache: bundler


### PR DESCRIPTION
http://docs.travis-ci.com/user/workers/container-based-infrastructure/

With Container based CI, public projects can cache the results of bundle 
install