### PR TITLE
Set Travis build distribution explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 sudo: false
 cache: bundler


### PR DESCRIPTION
 - travis changed the default distribution breaking build
   - travis default distribution changed from Trusty to Xenial
   - explicitly set to Trusty

---
[Travis switching to Xenial as the default build environment - but can't be bothered to tell you](https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476)

It's a nasty bug because you don't know it has changed the build distribution and you end up debugging the errors you see while you're wondering how this all happened in the first place.
This commit puts you back to Trusty, back to Green, while you work out how to manage the migration to Xenial under your own steam.
